### PR TITLE
UI/World Inspector Update

### DIFF
--- a/src/Inspectors/MouseInspector.cs
+++ b/src/Inspectors/MouseInspector.cs
@@ -30,7 +30,7 @@ namespace UnityExplorer.Inspectors
             MouseInspectMode.World => worldInspector,
             _ => null,
         };
-
+        
         private static Vector3 lastMousePos;
 
         // UIPanel
@@ -44,7 +44,8 @@ namespace UnityExplorer.Inspectors
         public override Vector2 DefaultAnchorMax => Vector2.zero;
 
         public override bool CanDragAndResize => false;
-
+        
+        internal Text inspectorLabelTitle;
         internal Text objNameLabel;
         internal Text objPathLabel;
         internal Text mousePosLabel;
@@ -181,7 +182,6 @@ namespace UnityExplorer.Inspectors
             Rect.pivot = new Vector2(0.5f, 1);
             Rect.sizeDelta = new Vector2(700, 150);
         }
-
         protected override void ConstructPanelContent()
         {
             // hide title bar
@@ -192,12 +192,11 @@ namespace UnityExplorer.Inspectors
             UIFactory.SetLayoutElement(inspectContent, flexibleWidth: 9999, flexibleHeight: 9999);
 
             // Title text
-
-            Text title = UIFactory.CreateLabel(inspectContent,
+            inspectorLabelTitle = UIFactory.CreateLabel(inspectContent,
                 "InspectLabel",
-                "<b>Mouse Inspector</b> (press <b>ESC</b> to cancel)",
+                "",
                 TextAnchor.MiddleCenter);
-            UIFactory.SetLayoutElement(title.gameObject, flexibleWidth: 9999);
+            UIFactory.SetLayoutElement(inspectorLabelTitle.gameObject, flexibleWidth: 9999);
 
             mousePosLabel = UIFactory.CreateLabel(inspectContent, "MousePosLabel", "Mouse Position:", TextAnchor.MiddleCenter);
 

--- a/src/Inspectors/MouseInspector.cs
+++ b/src/Inspectors/MouseInspector.cs
@@ -45,10 +45,10 @@ namespace UnityExplorer.Inspectors
 
         public override bool CanDragAndResize => false;
         
-        internal Text inspectorLabelTitle;
-        internal Text objNameLabel;
-        internal Text objPathLabel;
-        internal Text mousePosLabel;
+        private Text inspectorLabelTitle;
+        private Text objNameLabel;
+        private Text objPathLabel;
+        private Text mousePosLabel;
 
         public MouseInspector(UIBase owner) : base(owner)
         {
@@ -121,6 +121,45 @@ namespace UnityExplorer.Inspectors
                 UpdateInspect();
 
             return Inspecting;
+        }
+        
+        /// <summary>
+        /// Updates the title text in the inspector UI, if the inspector title label is assigned.
+        /// </summary>
+        /// <param name="title">The new title text to display in the inspector.</param>
+        internal void UpdateInspectorTitle(string title)
+        {
+            // Unity null check - if inspectorLabelTitle is assigned, update its text.
+            if (inspectorLabelTitle)
+            {
+                inspectorLabelTitle.text = title;
+            }
+        }
+
+        /// <summary>
+        /// Updates the object name label in the inspector UI, if the label is assigned.
+        /// </summary>
+        /// <param name="name">The new object name to display.</param>
+        internal void UpdateObjectNameLabel(string name)
+        {
+            // Unity null check - if objNameLabel is assigned, update its text.
+            if (objNameLabel)
+            {
+                objNameLabel.text = name;
+            }
+        }
+
+        /// <summary>
+        /// Updates the object path label in the inspector UI, if the label is assigned.
+        /// </summary>
+        /// <param name="path">The new object path to display.</param>
+        internal void UpdateObjectPathLabel(string path)
+        {
+            // Unity null check - if objPathLabel is assigned, update its text.
+            if (objPathLabel)
+            {
+                objPathLabel.text = path;
+            }
         }
 
         public void UpdateInspect()

--- a/src/Inspectors/MouseInspectors/UiInspector.cs
+++ b/src/Inspectors/MouseInspectors/UiInspector.cs
@@ -17,11 +17,13 @@ namespace UnityExplorer.Inspectors.MouseInspectors
         private static readonly List<CanvasGroup> wasDisabledCanvasGroups = new();
         private static readonly List<GameObject> objectsAddedCastersTo = new();
 
+        private const string DEFAULT_INSPECTOR_TITLE = "<b>UI Inspector</b> (press <b>ESC</b> to cancel)";
+
         public override void OnBeginMouseInspect()
         {
             SetupUIRaycast();
-            MouseInspector.Instance.inspectorLabelTitle.text = "<b>UI Inspector</b> (press <b>ESC</b> to cancel)";
-            MouseInspector.Instance.objPathLabel.text = "";
+            MouseInspector.Instance.UpdateInspectorTitle(DEFAULT_INSPECTOR_TITLE);
+            MouseInspector.Instance.UpdateObjectPathLabel("");
         }
 
         public override void ClearHitData()
@@ -71,9 +73,9 @@ namespace UnityExplorer.Inspectors.MouseInspectors
             }
 
             if (currentHitObjects.Any())
-                MouseInspector.Instance.objNameLabel.text = $"Click to view UI Objects under mouse: {currentHitObjects.Count}";
+                MouseInspector.Instance.UpdateObjectNameLabel($"Click to view UI Objects under mouse: {currentHitObjects.Count}");
             else
-                MouseInspector.Instance.objNameLabel.text = $"No UI objects under mouse.";
+                MouseInspector.Instance.UpdateObjectNameLabel("No UI objects under mouse.");
         }
 
         private static void SetupUIRaycast()

--- a/src/Inspectors/MouseInspectors/UiInspector.cs
+++ b/src/Inspectors/MouseInspectors/UiInspector.cs
@@ -20,6 +20,7 @@ namespace UnityExplorer.Inspectors.MouseInspectors
         public override void OnBeginMouseInspect()
         {
             SetupUIRaycast();
+            MouseInspector.Instance.inspectorLabelTitle.text = "<b>UI Inspector</b> (press <b>ESC</b> to cancel)";
             MouseInspector.Instance.objPathLabel.text = "";
         }
 

--- a/src/Inspectors/MouseInspectors/WorldInspector.cs
+++ b/src/Inspectors/MouseInspectors/WorldInspector.cs
@@ -2,20 +2,37 @@
 {
     public class WorldInspector : MouseInspectorBase
     {
-        private static Camera MainCamera;
+        internal static Camera MainCamera;
         private static GameObject lastHitObject;
 
         public override void OnBeginMouseInspect()
         {
             MainCamera = Camera.main;
+            var camList = Camera.allCameras.ToList();
 
             if (!MainCamera)
             {
-                ExplorerCore.LogWarning("No MainCamera found! Cannot inspect world!");
-                return;
+                ExplorerCore.LogWarning("No Main Camera was found, trying to find a camera named 'Main Camera' or 'MainCamera'");
+                // Try to find a camera named "Main Camera" or "MainCamera"
+                MainCamera = camList.FirstOrDefault(c => c.name is "Main Camera" or "MainCamera");
+                if (!MainCamera)
+                {
+                    ExplorerCore.LogWarning("No camera named 'Main Camera' or 'MainCamera' found, using the first camera created");
+                    
+                    // If no camera is named "Main Camera" or "MainCamera", use the first camera that was created
+                    MainCamera = camList.FirstOrDefault();
+                    if (!MainCamera)
+                    {
+                        //this should never happen
+                        ExplorerCore.LogWarning("No valid cameras found! Cannot inspect world!");
+                        return;
+                    }
+                }
             }
-        }
 
+            MouseInspector.Instance.inspectorLabelTitle.text = $"<b>World Inspector ({MainCamera.name})</b> (press <b>ESC</b> to cancel)";
+            ExplorerCore.Log($"Using camera: '{MainCamera.transform.GetTransformPath(true)}'");
+        }
         public override void ClearHitData()
         {
             lastHitObject = null;


### PR DESCRIPTION
This PR enhances the camera selection logic used when initializing world inspection. 

Previously, the code relied solely on Camera.main - which only works if a camera is tagged as "Main Camera." 

If developers have used a different naming convention (e.g., "MainCamera") or no tag at all, inspection would fail to proceed.

Inspector title is updated dynamically to reflect the camera being used so that users are aware.