### PR TITLE
Console Fixes

### DIFF
--- a/src/CSConsole/ConsoleController.cs
+++ b/src/CSConsole/ConsoleController.cs
@@ -860,12 +860,12 @@ Doorstop example:
         SelectedDropDown(prevSelect);
     }
 
-    internal const string STARTUP_TEXT = @"<color=#5d8556>// Welcome to the UnityExplorer C# Console!
+    internal const string STARTUP_TEXT = @"// Welcome to the UnityExplorer C# Console!
 
 // It is recommended to use the Log panel (or a console log window) while using this tool.
 // Use the Help dropdown to see detailed examples of how to use the console.
 
-// To execute a script automatically on startup, put the script at 'sinai-dev-UnityExplorer\Scripts\startup.cs'</color>";
+// To execute a script automatically on startup, put the script at 'sinai-dev-UnityExplorer\Scripts\startup.cs'";
 
     internal const string HELP_USINGS = @"// You can add a using directive to any namespace, but you must compile for it to take effect.
 // It will remain in effect until you Reset the console.

--- a/src/UI/Panels/CSConsolePanel.cs
+++ b/src/UI/Panels/CSConsolePanel.cs
@@ -83,7 +83,7 @@ namespace UnityExplorer.UI.Panels
             // Help dropdown
 
             GameObject helpDrop = UIFactory.CreateDropdown(toolsRow, "HelpDropdown", out Dropdown dropdown, "Help", 14, null);
-            UIFactory.SetLayoutElement(helpDrop, minHeight: 25, minWidth: 100);
+            UIFactory.SetLayoutElement(helpDrop, minHeight: 25, minWidth: 100, flexibleWidth: 9999);
             Dropdown = dropdown;
             Dropdown.onValueChanged.AddListener((int val) => { this.OnDropdownChanged?.Invoke(val); });
 


### PR DESCRIPTION
- Fixed "Welcome" help message formatting being broken when clicking the refresh button due to it having `<color>`
- Made the "help dropdown" width flexible since .cs files with long names don't show the full name on the existing version