### PR TITLE
Fix: C# Console selection highlight missing 

### DIFF
--- a/src/CSConsole/ConsoleController.cs
+++ b/src/CSConsole/ConsoleController.cs
@@ -20,7 +20,7 @@ public class ConsoleController
     private bool sreNotSupported { get; set; }
     private int lastCaretPosition { get;  set; }
     // Fix: Assignment to DefaultInputFieldAlpha failed due to instance not being created before Init
-    public static float DefaultInputFieldAlpha = 0f;
+    public static float DefaultInputFieldAlpha { get; set; }
 
     private bool enableCtrlRShortcut { get; set; } = true;
     private bool enableAutoIndent { get; set; } = true;


### PR DESCRIPTION
Problem
In commit [5710d71](https://github.com/yukieiji/UnityExplorer/commit/5710d71e224ef4118aaeca65a707f52d24c82e06), the setter of DefaultInputFieldAlpha was changed to write to a private field that requires an instance created during Init. However, DefaultInputFieldAlpha is assigned before Init is called, causing the assignment to silently fail and the value to be lost.

https://github.com/yukieiji/UnityExplorer/blob/6d2ca5c400fad844d6e82feeb409ff3cc5a3e28f/src/UI/UIManager.cs#L89-L102


![Example of a problem](https://github.com/user-attachments/assets/7e36ca32-6a30-4890-b080-25a7d84f75fa)

Impact
The selection highlight in the C# Console disappears because the input field alpha value defaults to 0 instead of the expected value.