### PR TITLE
日本語ナビバーのボタンを2行に修正

### DIFF
--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -219,7 +219,7 @@ namespace UnityExplorer.UI
         {
             GameObject navbarPanel = UIFactory.CreateUIObject("MainNavbar", UIRoot);
             bool isJP = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese;
-            UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(navbarPanel, false, false, true, !isJP, 5, 4, 4, 4, 4, TextAnchor.MiddleCenter);
+            UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(navbarPanel, false, false, true, true, 5, 4, 4, 4, 4, TextAnchor.MiddleCenter);
             navbarPanel.AddComponent<Image>().color = new Color(0.1f, 0.1f, 0.1f);
             NavBarRect = navbarPanel.GetComponent<RectTransform>();
             NavBarRect.pivot = new Vector2(0.5f, 1f);
@@ -236,7 +236,7 @@ namespace UnityExplorer.UI
 
             string titleTxt = $"UE <i><color=grey>{ExplorerCore.VERSION}</color></i>";
             Text title = UIFactory.CreateLabel(navbarPanel, "Title", titleTxt, TextAnchor.MiddleCenter, default, true, 14);
-            UIFactory.SetLayoutElement(title.gameObject, minWidth: 75, minHeight: 25, flexibleWidth: 0);
+            UIFactory.SetLayoutElement(title.gameObject, minWidth: 75, flexibleWidth: 0);
 
             // panel tabs
 
@@ -263,7 +263,7 @@ namespace UnityExplorer.UI
 
             //spacer
             GameObject spacer = UIFactory.CreateUIObject("Spacer", navbarPanel);
-            UIFactory.SetLayoutElement(spacer, minWidth: 15, minHeight: 25);
+            UIFactory.SetLayoutElement(spacer, minWidth: 15);
 
             // Hide menu button
 

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -165,22 +165,21 @@ namespace UnityExplorer.UI
         public static void SetNavBarAnchor()
         {
             float height = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese ? 62 : 35;
-            Vector2 dimensions = new(NAVBAR_DIMENSIONS.x, height);
 
             switch (NavbarAnchor)
             {
                 case VerticalAnchor.Top:
-                    NavBarRect.anchorMin = new Vector2(0.5f, 1f);
-                    NavBarRect.anchorMax = new Vector2(0.5f, 1f);
-                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, 0);
-                    NavBarRect.sizeDelta = dimensions;
+                    NavBarRect.anchorMin = new Vector2(0f, 1f);
+                    NavBarRect.anchorMax = new Vector2(1f, 1f);
+                    NavBarRect.anchoredPosition = new Vector2(0, 0);
+                    NavBarRect.sizeDelta = new Vector2(0, height);
                     break;
 
                 case VerticalAnchor.Bottom:
-                    NavBarRect.anchorMin = new Vector2(0.5f, 0f);
-                    NavBarRect.anchorMax = new Vector2(0.5f, 0f);
-                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, height);
-                    NavBarRect.sizeDelta = dimensions;
+                    NavBarRect.anchorMin = new Vector2(0f, 0f);
+                    NavBarRect.anchorMax = new Vector2(1f, 0f);
+                    NavBarRect.anchoredPosition = new Vector2(0, height);
+                    NavBarRect.sizeDelta = new Vector2(0, height);
                     break;
             }
         }
@@ -245,7 +244,7 @@ namespace UnityExplorer.UI
             {
                 UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 54, flexibleHeight: 0, flexibleWidth: 999);
                 GridLayoutGroup grid = NavbarTabButtonHolder.AddComponent<GridLayoutGroup>();
-                grid.cellSize = new Vector2(160, 25);
+                grid.cellSize = new Vector2(180, 25);
                 grid.spacing = new Vector2(4, 4);
                 grid.childAlignment = TextAnchor.MiddleCenter;
                 grid.constraint = GridLayoutGroup.Constraint.FixedRowCount;

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -164,20 +164,23 @@ namespace UnityExplorer.UI
 
         public static void SetNavBarAnchor()
         {
+            float height = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese ? 62 : 35;
+            Vector2 dimensions = new(NAVBAR_DIMENSIONS.x, height);
+
             switch (NavbarAnchor)
             {
                 case VerticalAnchor.Top:
                     NavBarRect.anchorMin = new Vector2(0.5f, 1f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 1f);
                     NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, 0);
-                    NavBarRect.sizeDelta = NAVBAR_DIMENSIONS;
+                    NavBarRect.sizeDelta = dimensions;
                     break;
 
                 case VerticalAnchor.Bottom:
                     NavBarRect.anchorMin = new Vector2(0.5f, 0f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 0f);
-                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, 35);
-                    NavBarRect.sizeDelta = NAVBAR_DIMENSIONS;
+                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, height);
+                    NavBarRect.sizeDelta = dimensions;
                     break;
             }
         }
@@ -215,7 +218,8 @@ namespace UnityExplorer.UI
         private static void CreateTopNavBar()
         {
             GameObject navbarPanel = UIFactory.CreateUIObject("MainNavbar", UIRoot);
-            UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(navbarPanel, false, false, true, true, 5, 4, 4, 4, 4, TextAnchor.MiddleCenter);
+            bool isJP = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese;
+            UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(navbarPanel, false, false, true, !isJP, 5, 4, 4, 4, 4, TextAnchor.MiddleCenter);
             navbarPanel.AddComponent<Image>().color = new Color(0.1f, 0.1f, 0.1f);
             NavBarRect = navbarPanel.GetComponent<RectTransform>();
             NavBarRect.pivot = new Vector2(0.5f, 1f);
@@ -232,20 +236,34 @@ namespace UnityExplorer.UI
 
             string titleTxt = $"UE <i><color=grey>{ExplorerCore.VERSION}</color></i>";
             Text title = UIFactory.CreateLabel(navbarPanel, "Title", titleTxt, TextAnchor.MiddleCenter, default, true, 14);
-            UIFactory.SetLayoutElement(title.gameObject, minWidth: 75, flexibleWidth: 0);
+            UIFactory.SetLayoutElement(title.gameObject, minWidth: 75, minHeight: 25, flexibleWidth: 0);
 
             // panel tabs
 
             NavbarTabButtonHolder = UIFactory.CreateUIObject("NavTabButtonHolder", navbarPanel);
-            UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 25, flexibleHeight: 999, flexibleWidth: 999);
-            UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(NavbarTabButtonHolder, false, true, true, true, 4, 2, 2, 2, 2);
+            if (isJP)
+            {
+                UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 54, flexibleHeight: 0, flexibleWidth: 999);
+                GridLayoutGroup grid = NavbarTabButtonHolder.AddComponent<GridLayoutGroup>();
+                grid.cellSize = new Vector2(160, 25);
+                grid.spacing = new Vector2(4, 4);
+                grid.childAlignment = TextAnchor.MiddleCenter;
+                grid.constraint = GridLayoutGroup.Constraint.FixedRowCount;
+                grid.constraintCount = 2;
+                grid.startAxis = GridLayoutGroup.Axis.Horizontal;
+            }
+            else
+            {
+                UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 25, flexibleHeight: 999, flexibleWidth: 999);
+                UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(NavbarTabButtonHolder, false, true, true, true, 4, 2, 2, 2, 2);
+            }
 
             // Time scale widget
             TimeScaleWidget.SetUp(navbarPanel);
 
             //spacer
             GameObject spacer = UIFactory.CreateUIObject("Spacer", navbarPanel);
-            UIFactory.SetLayoutElement(spacer, minWidth: 15);
+            UIFactory.SetLayoutElement(spacer, minWidth: 15, minHeight: 25);
 
             // Hide menu button
 

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -164,21 +164,21 @@ namespace UnityExplorer.UI
 
         public static void SetNavBarAnchor()
         {
-            float height = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese ? 62 : 35;
+            float height = IsTabNavBarUseSecondRow() ? 62 : 35;
 
             switch (NavbarAnchor)
             {
                 case VerticalAnchor.Top:
                     NavBarRect.anchorMin = new Vector2(0.5f, 1f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 1f);
-                    NavBarRect.anchoredPosition = new Vector2(0, 0);
+                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, 0);
                     NavBarRect.sizeDelta = new Vector2(NAVBAR_WIDTH, height);
                     break;
 
                 case VerticalAnchor.Bottom:
                     NavBarRect.anchorMin = new Vector2(0.5f, 0f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 0f);
-                    NavBarRect.anchoredPosition = new Vector2(0, height);
+                    NavBarRect.anchoredPosition = new Vector2(NavBarRect.anchoredPosition.x, height);
                     NavBarRect.sizeDelta = new Vector2(NAVBAR_WIDTH, height);
                     break;
             }
@@ -217,7 +217,6 @@ namespace UnityExplorer.UI
         private static void CreateTopNavBar()
         {
             GameObject navbarPanel = UIFactory.CreateUIObject("MainNavbar", UIRoot);
-            bool isJP = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese;
             UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(navbarPanel, false, false, true, true, 5, 4, 4, 4, 4, TextAnchor.MiddleCenter);
             navbarPanel.AddComponent<Image>().color = new Color(0.1f, 0.1f, 0.1f);
             NavBarRect = navbarPanel.GetComponent<RectTransform>();
@@ -240,7 +239,7 @@ namespace UnityExplorer.UI
             // panel tabs
 
             NavbarTabButtonHolder = UIFactory.CreateUIObject("NavTabButtonHolder", navbarPanel);
-            if (isJP)
+            if (IsTabNavBarUseSecondRow())
             {
                 UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 44, flexibleHeight: 0, flexibleWidth: 999);
                 GridLayoutGroup grid = NavbarTabButtonHolder.AddComponent<GridLayoutGroup>();
@@ -273,6 +272,11 @@ namespace UnityExplorer.UI
 
             ConfigManager.Master_Toggle.OnValueChanged += Master_Toggle_OnValueChanged;
             closeBtn.OnClick += OnCloseButtonClicked;
+        }
+
+        private static bool IsTabNavBarUseSecondRow()
+        {
+            return ConfigManager.Lang_Toggle.Value is TranslationManager.Lang.Japanese;
         }
     }
 }

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -165,21 +165,22 @@ namespace UnityExplorer.UI
         public static void SetNavBarAnchor()
         {
             float height = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese ? 62 : 35;
+            float width = lastScreenWidth * 0.8f;
 
             switch (NavbarAnchor)
             {
                 case VerticalAnchor.Top:
-                    NavBarRect.anchorMin = new Vector2(0f, 1f);
-                    NavBarRect.anchorMax = new Vector2(1f, 1f);
+                    NavBarRect.anchorMin = new Vector2(0.5f, 1f);
+                    NavBarRect.anchorMax = new Vector2(0.5f, 1f);
                     NavBarRect.anchoredPosition = new Vector2(0, 0);
-                    NavBarRect.sizeDelta = new Vector2(0, height);
+                    NavBarRect.sizeDelta = new Vector2(width, height);
                     break;
 
                 case VerticalAnchor.Bottom:
-                    NavBarRect.anchorMin = new Vector2(0f, 0f);
-                    NavBarRect.anchorMax = new Vector2(1f, 0f);
+                    NavBarRect.anchorMin = new Vector2(0.5f, 0f);
+                    NavBarRect.anchorMax = new Vector2(0.5f, 0f);
                     NavBarRect.anchoredPosition = new Vector2(0, height);
-                    NavBarRect.sizeDelta = new Vector2(0, height);
+                    NavBarRect.sizeDelta = new Vector2(width, height);
                     break;
             }
         }
@@ -191,6 +192,8 @@ namespace UnityExplorer.UI
             Display display = DisplayManager.ActiveDisplay;
             lastScreenWidth = display.renderingWidth;
             lastScreenHeight = display.renderingHeight;
+
+            SetNavBarAnchor();
 
             foreach (KeyValuePair<Panels, UEPanel> panel in UIPanels)
             {

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -44,7 +44,7 @@ namespace UnityExplorer.UI
 
         public static RectTransform NavBarRect;
         public static GameObject NavbarTabButtonHolder;
-        private static readonly Vector2 NAVBAR_DIMENSIONS = new(1020f, 35f);
+        private static readonly float NAVBAR_WIDTH = 1020f;
 
         private static ButtonRef closeBtn;
 
@@ -165,7 +165,6 @@ namespace UnityExplorer.UI
         public static void SetNavBarAnchor()
         {
             float height = ConfigManager.Lang_Toggle.Value == TranslationManager.Lang.Japanese ? 62 : 35;
-            float width = lastScreenWidth * 0.8f;
 
             switch (NavbarAnchor)
             {
@@ -173,14 +172,14 @@ namespace UnityExplorer.UI
                     NavBarRect.anchorMin = new Vector2(0.5f, 1f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 1f);
                     NavBarRect.anchoredPosition = new Vector2(0, 0);
-                    NavBarRect.sizeDelta = new Vector2(width, height);
+                    NavBarRect.sizeDelta = new Vector2(NAVBAR_WIDTH, height);
                     break;
 
                 case VerticalAnchor.Bottom:
                     NavBarRect.anchorMin = new Vector2(0.5f, 0f);
                     NavBarRect.anchorMax = new Vector2(0.5f, 0f);
                     NavBarRect.anchoredPosition = new Vector2(0, height);
-                    NavBarRect.sizeDelta = new Vector2(width, height);
+                    NavBarRect.sizeDelta = new Vector2(NAVBAR_WIDTH, height);
                     break;
             }
         }
@@ -192,8 +191,6 @@ namespace UnityExplorer.UI
             Display display = DisplayManager.ActiveDisplay;
             lastScreenWidth = display.renderingWidth;
             lastScreenHeight = display.renderingHeight;
-
-            SetNavBarAnchor();
 
             foreach (KeyValuePair<Panels, UEPanel> panel in UIPanels)
             {
@@ -245,9 +242,9 @@ namespace UnityExplorer.UI
             NavbarTabButtonHolder = UIFactory.CreateUIObject("NavTabButtonHolder", navbarPanel);
             if (isJP)
             {
-                UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 54, flexibleHeight: 0, flexibleWidth: 999);
+                UIFactory.SetLayoutElement(NavbarTabButtonHolder, minHeight: 44, flexibleHeight: 0, flexibleWidth: 999);
                 GridLayoutGroup grid = NavbarTabButtonHolder.AddComponent<GridLayoutGroup>();
-                grid.cellSize = new Vector2(180, 25);
+                grid.cellSize = new Vector2(224, 20);
                 grid.spacing = new Vector2(4, 4);
                 grid.childAlignment = TextAnchor.MiddleCenter;
                 grid.constraint = GridLayoutGroup.Constraint.FixedRowCount;


### PR DESCRIPTION
言語が日本語に設定されている場合、ナビバーの高さを拡大し、ボタンを2行のグリッド表示に切り替えるように修正しました。これにより、日本語の長いボタン名でもUIが崩れたりはみ出したりするのを防ぎます。

---
*PR created automatically by Jules for task [13630758773756820482](https://jules.google.com/task/13630758773756820482) started by @yukieiji*